### PR TITLE
Make the duplicate mapping tests more comprehensive.

### DIFF
--- a/include/ros2_serial_example/std_msgs_String_Subscription.hpp
+++ b/include/ros2_serial_example/std_msgs_String_Subscription.hpp
@@ -10,16 +10,18 @@
 #include <fastcdr/FastCdr.h>
 
 #include "ros2_serial_example/subscription.hpp"
+#include "ros2_serial_example/transporter.hpp"
 
 class std_msgs_String_Subscription : public Subscription
 {
 public:
     explicit std_msgs_String_Subscription(const std::shared_ptr<rclcpp::Node> & node,
-                                          topic_id_size_t serial_mapping,
+                                          topic_id_size_t mapping,
                                           const std::string & name,
                                           std::shared_ptr<Transporter> transporter)
     {
-        auto callback = [serial_mapping, transporter](const std_msgs::msg::String::SharedPtr msg) -> void
+        serial_mapping = mapping;
+        auto callback = [mapping, transporter](const std_msgs::msg::String::SharedPtr msg) -> void
         {
             size_t headlen = transporter->get_header_length();
             // From empirical testing, we know that doing CDR framing on strings results
@@ -28,7 +30,7 @@ public:
             eprosima::fastcdr::FastBuffer cdrbuffer(&data_buffer[headlen], msg->data.size() + 5);
             eprosima::fastcdr::Cdr scdr(cdrbuffer);
             scdr << msg->data;
-            transporter->write(serial_mapping, data_buffer, scdr.getSerializedDataLength());
+            transporter->write(mapping, data_buffer, scdr.getSerializedDataLength());
             delete [] data_buffer;
         };
         sub = node->create_subscription<std_msgs::msg::String>(name, callback, rmw_qos_profile_default);

--- a/include/ros2_serial_example/subscription.hpp
+++ b/include/ros2_serial_example/subscription.hpp
@@ -1,5 +1,15 @@
 #pragma once
 
+#include "ros2_serial_example/transporter.hpp"
+
 class Subscription
 {
+public:
+    topic_id_size_t get_serial_mapping() const
+    {
+        return serial_mapping;
+    }
+
+protected:
+    topic_id_size_t serial_mapping;
 };


### PR DESCRIPTION
This will ensure that we don't have duplicate serial mappings for either publishers or subscribers.