### PR TITLE
Rename the serializer to ros2_to_serial_bridge.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,18 +68,18 @@ endforeach()
 
 list(REMOVE_DUPLICATES _deps)
 
-add_executable(ros2_serializer
-  src/ros2_serializer.cpp
+add_executable(ros2_to_serial_bridge
+  src/ros2_to_serial_bridge.cpp
   src/transporter.cpp
   src/uart_transporter.cpp
   ${_ros2_topics}
 )
-ament_target_dependencies(ros2_serializer
+ament_target_dependencies(ros2_to_serial_bridge
   fastcdr
   rclcpp
   ${_deps}
 )
-target_link_libraries(ros2_serializer
+target_link_libraries(ros2_to_serial_bridge
   fastcdr
 )
 
@@ -96,7 +96,7 @@ target_link_libraries(serial_writer
 )
 
 install(TARGETS
-  ros2_serializer
+  ros2_to_serial_bridge
   serial_writer
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/config/default_ros2_to_serial_bridge_params.yaml
+++ b/config/default_ros2_to_serial_bridge_params.yaml
@@ -1,4 +1,4 @@
-ros2_serializer:
+ros2_to_serial_bridge:
     ros__parameters:
         chatter:
             serial_mapping: 9

--- a/src/ros2_to_serial_bridge.cpp
+++ b/src/ros2_to_serial_bridge.cpp
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
         return ret;
     }
 
-    auto node = rclcpp::Node::make_shared("ros2_serializer");
+    auto node = rclcpp::Node::make_shared("ros2_to_serial_bridge");
 
     std::shared_ptr<Transporter> transporter = std::make_shared<UARTTransporter>(device.c_str(), B115200, 0);
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>