### PR TITLE
Baudrate

### DIFF
--- a/include/ros2_serial_example/uart_transporter.hpp
+++ b/include/ros2_serial_example/uart_transporter.hpp
@@ -64,9 +64,10 @@ private:
     bool fds_OK() override;
 
     SerialProtocol serial_protocol;
-    int uart_fd;
     char uart_name[64] = {};
     uint32_t baudrate;
     uint32_t poll_ms;
+    int uart_fd;
+    uint32_t write_timeout_us;
     struct pollfd poll_fd[1] = {};
 };

--- a/src/uart_transporter.cpp
+++ b/src/uart_transporter.cpp
@@ -107,8 +107,8 @@ int UARTTransporter::init()
         return -errno_bkp;
     }
 
-    //Set up the UART for non-canonical binary communication: 8 bits, 1 stop bit, no parity,
-    //no flow control, no modem control
+    // Set up the UART for non-canonical binary communication: 8 bits, 1 stop bit, no parity,
+    // no flow control, no modem control
     uart_config.c_iflag &= !(INPCK | ISTRIP | INLCR | IGNCR | ICRNL | IXON | IXANY | IXOFF);
     uart_config.c_iflag |= IGNBRK | IGNPAR;
 
@@ -120,18 +120,13 @@ int UARTTransporter::init()
 
     uart_config.c_lflag &= !(ISIG | ICANON | ECHO | TOSTOP | IEXTEN);
 
-    // USB serial is indicated by /dev/ttyACM0
-    // TODO(clalancette): this is arbitrary, probably remove this
-    if (::strcmp(uart_name, "/dev/ttyACM0") != 0 && ::strcmp(uart_name, "/dev/ttyACM1") != 0)
+    // Set baud rate
+    if (::cfsetispeed(&uart_config, baudrate) < 0 || ::cfsetospeed(&uart_config, baudrate) < 0)
     {
-        // Set baud rate
-        if (::cfsetispeed(&uart_config, baudrate) < 0 || ::cfsetospeed(&uart_config, baudrate) < 0)
-        {
-            int errno_bkp = errno;
-            ::printf("ERR SET BAUD %s: %d (%d)\n", uart_name, termios_state, errno);
-            close();
-            return -errno_bkp;
-        }
+        int errno_bkp = errno;
+        ::printf("ERR SET BAUD %s: %d (%d)\n", uart_name, termios_state, errno);
+        close();
+        return -errno_bkp;
     }
 
     if ((termios_state = ::tcsetattr(uart_fd, TCSANOW, &uart_config)) < 0)


### PR DESCRIPTION
Allow configuration of the baudrate.

For the ros2_to_serial_bridge (the main component of this repository), the baudrate is configured as a number in the parameters file.  For the dummy serial component, it is passed as a command-line argument (since it is not a ROS 2 component).

There are also some fixes in here:
1.  Remove the arbitrary handling of /dev/ttyACM devices at the UART layer
1.  To allow passing a "0" baudrate (essentially skipping termios configuration)
1.  To handle semi-permanent write errors gracefully