### PR TITLE
Allow the read-side polling to sleep for up to 100ms.

### DIFF
--- a/src/dummy_serial.cpp
+++ b/src/dummy_serial.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    std::unique_ptr<Transporter> transporter = std::make_unique<UARTTransporter>(std::string(device), "px4", baudrate, 1);
+    std::unique_ptr<Transporter> transporter = std::make_unique<UARTTransporter>(std::string(device), "px4", baudrate, 100);
 
     if (transporter->init() < 0)
     {

--- a/src/ros2_to_serial_bridge.cpp
+++ b/src/ros2_to_serial_bridge.cpp
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
         baudrate = 0;
     }
 
-    std::shared_ptr<Transporter> transporter = std::make_shared<UARTTransporter>(device, serial_protocol, baudrate, 1);
+    std::shared_ptr<Transporter> transporter = std::make_shared<UARTTransporter>(device, serial_protocol, baudrate, 100);
 
     if (transporter->init() < 0)
     {


### PR DESCRIPTION
This provides a good compromise between latency and CPU time.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>