### PR TITLE
Add in tests for the ring buffer implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ foreach(msg ${_msgs})
 endforeach()
 list(REMOVE_DUPLICATES _deps)
 
+add_library(ring_buffer
+  src/ring_buffer.cpp
+)
+
 add_executable(ros2_to_serial_bridge
   src/ros2_to_serial_bridge.cpp
   src/transporter.cpp
@@ -82,6 +86,7 @@ ament_target_dependencies(ros2_to_serial_bridge
 )
 target_link_libraries(ros2_to_serial_bridge
   fastcdr
+  ring_buffer
 )
 
 add_executable(dummy_serial
@@ -94,7 +99,14 @@ ament_target_dependencies(dummy_serial
 )
 target_link_libraries(dummy_serial
   fastcdr
+  ring_buffer
   ${CMAKE_THREAD_LIBS_INIT}
+)
+
+install(TARGETS ring_buffer
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(TARGETS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,4 +115,11 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_ring_buffer test/test_ring_buffer.cpp)
+  target_link_libraries(test_ring_buffer ring_buffer)
+endif()
+
 ament_package()

--- a/include/ros2_serial_example/ring_buffer.hpp
+++ b/include/ros2_serial_example/ring_buffer.hpp
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 
 namespace ros2_to_serial_bridge
 {
@@ -25,36 +27,137 @@ namespace transport
 namespace impl
 {
 
-class RingBuffer final
+/**
+ * The RingBuffer class provides a C++-like API on top of a ring buffer
+ * implementation.
+ *
+ * The general idea behind the ring buffer is that there are two pointers,
+ * 'head' and 'tail'.  New data coming in is added at the head pointer, and the
+ * head pointer is then updated.  If the number of incoming bytes exceeds the
+ * size of the ring, then the 'full' flag is set.  Data being removed from the
+ * buffer is read from the tail pointer, and the tail pointer is then updated.
+ * If the full flag is set, and head == tail, the ring buffer is full.  If the
+ * full flag is not set, and head == tail, the ring buffer is empty.  If the
+ * ring buffer becomes full, and new data is attempted to be added, the oldest
+ * data in the ring is overwritten and lost.
+ *
+ * This implementation only expects a single reader and writer at a time, so
+ * multi-threaded programs should protect accesses with a mutex.
+ *
+ * One semi-unique feature of this implementation is the read() method, which
+ * does a POSIX read directly into the read buffer.
+ */
+class RingBuffer
 {
 public:
     explicit RingBuffer(size_t capacity);
 
     virtual ~RingBuffer();
 
+    /**
+     * Read data from a file descriptor directly into the ring buffer.
+     *
+     * This improves performance by skipping a read() followed by a copy into the
+     * ring buffer.
+     *
+     * @param[in] fd The file descriptor to read data out of.
+     * @returns The number of bytes read on success, or -1 on error.
+     *
+     * @note This method can and does do short reads, either because the
+     *       underlying file descriptor returned a short read or because the
+     *       internal mechanics of the ring buffer implementation forced it to.
+     *       Callers should be prepared to deal with short reads.
+     *
+     * @note This method expects that the file descriptor passed in is
+     *       non-blocking and returns immediately if there is no data available.
+     *       Passing a blocking file descriptor here could cause this method
+     *       to block for long periods of time.
+     */
     ssize_t read(int fd);
 
-    void *peek(void *dst, size_t count);
+    /**
+     * Look at the data currently in the ring buffer without removing it.
+     *
+     * The ring buffer is not altered.  This call can fail if the ring buffer
+     * doesn't contain at least the number of bytes requested.
+     *
+     * @param[out] dst The destination buffer for the data; this should be
+     *                 at least as large as count.
+     * @param[in] count The size of data to look for in the ring buffer.
+     * @returns The number of bytes copied out on success, or -1 on error.
+     */
+    ssize_t peek(void *dst, size_t count) const;
 
-    void *memcpy_from(void *dst, size_t count);
+    /**
+     * Copy data out of the ring buffer into a linear buffer.
+     *
+     * If there isn't enough data in the buffer for the number of bytes
+     * requested, or the number of bytes requested is 0, or the destination
+     * is a nullptr, this returns -1.  Otherwise it removes the requested
+     * number of bytes from the ring.
+     *
+     * @param[out] dst The destination buffer for the data; this should be
+     *                 at least as large as count.
+     * @param[in] count The size of the data to copy out of the ring buffer.
+     * @returns The number of bytes copied out on success, or -1 on error.
+     */
+    ssize_t memcpy_from(void *dst, size_t count);
 
-    size_t findseq(uint8_t *seq, size_t seqlen);
+    /**
+     * Find a particular sequence of bytes in the ring buffer.
+     *
+     * If the sequence of bytes is found, then the offset from the 'tail' of
+     * the ring is returned.  This is the number of bytes that would have to be
+     * copied out of the ring to get to the sequence.  If the sequence cannot
+     * be found for any reason, -1 is returned.
+     *
+     * @param[in] seq The byte sequence to look for in the ring; this should be
+     *                at least as large as seqlen.
+     * @param[in] seqlen The length of the byte sequence to look for.
+     * @returns The offset from the tail of the ring on success, -1 on error.
+     */
+    ssize_t findseq(const uint8_t *seq, size_t seqlen) const;
 
+    /**
+     * Get the number of valid bytes the ring buffer is using.
+     *
+     * @returns The number of valid bytes the ring buffer is using.
+     */
     size_t bytes_used() const;
 
+    /**
+     * Returns whether the ring buffer is currently full.
+     *
+     * @returns true if the ring buffer is full, false otherwise.
+     */
     bool is_full() const;
 
-private:
-    size_t buffer_size() const;
-    size_t capacity() const;
+protected:
+    /**
+     * Get a pointer to the end of the ring buffer.
+     *
+     * @returns a pointer to the end of the ring buffer.
+     */
     uint8_t *end() const;
-    size_t bytes_free() const;
-    bool is_empty() const;
-    uint8_t *nextp(uint8_t *p);
 
-    uint8_t *buf;
+    /**
+     * Get the number of bytes free in the ring buffer.
+     *
+     * @returns the number of bytes free in the ring buffer.
+     */
+    size_t bytes_free() const;
+
+    /**
+     * Determine whether the ring buffer is empty.
+     *
+     * @returns true if the ring buffer is empty, false otherwise.
+     */
+    bool is_empty() const;
+
+    std::unique_ptr<uint8_t[]> buf;
     uint8_t *head;
     uint8_t *tail;
+    bool full{false};
     size_t size;
 };
 

--- a/include/ros2_serial_example/ring_buffer.hpp
+++ b/include/ros2_serial_example/ring_buffer.hpp
@@ -1,0 +1,65 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace ros2_to_serial_bridge
+{
+
+namespace transport
+{
+
+namespace impl
+{
+
+class RingBuffer final
+{
+public:
+    explicit RingBuffer(size_t capacity);
+
+    virtual ~RingBuffer();
+
+    ssize_t read(int fd);
+
+    void *peek(void *dst, size_t count);
+
+    void *memcpy_from(void *dst, size_t count);
+
+    size_t findseq(uint8_t *seq, size_t seqlen);
+
+    size_t bytes_used() const;
+
+    bool is_full() const;
+
+private:
+    size_t buffer_size() const;
+    size_t capacity() const;
+    uint8_t *end() const;
+    size_t bytes_free() const;
+    bool is_empty() const;
+    uint8_t *nextp(uint8_t *p);
+
+    uint8_t *buf;
+    uint8_t *head;
+    uint8_t *tail;
+    size_t size;
+};
+
+}  // namespace impl
+
+}  // namespace transport
+
+}  // namespace ros2_to_serial_bridge

--- a/include/ros2_serial_example/transporter.hpp
+++ b/include/ros2_serial_example/transporter.hpp
@@ -39,6 +39,8 @@
 
 #include <cstdint>
 
+#include "ros2_serial_example/ring_buffer.hpp"
+
 // If you want to allow > 255 topic name/topic types on the serial wire,
 // increase the size of this typedef.  Note that it will break on-wire
 // serial compatibility.
@@ -49,44 +51,6 @@ namespace ros2_to_serial_bridge
 
 namespace transport
 {
-
-namespace impl
-{
-
-class RingBuffer final
-{
-public:
-    explicit RingBuffer(size_t capacity);
-
-    virtual ~RingBuffer();
-
-    ssize_t read(int fd);
-
-    void *peek(void *dst, size_t count);
-
-    void *memcpy_from(void *dst, size_t count);
-
-    size_t findseq(uint8_t *seq, size_t seqlen);
-
-    size_t bytes_used() const;
-
-    bool is_full() const;
-
-private:
-    size_t buffer_size() const;
-    size_t capacity() const;
-    uint8_t *end() const;
-    size_t bytes_free() const;
-    bool is_empty() const;
-    uint8_t *nextp(uint8_t *p);
-
-    uint8_t *buf;
-    uint8_t *head;
-    uint8_t *tail;
-    size_t size;
-};
-
-}  // namespace impl
 
 class Transporter
 {

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/ring_buffer.cpp
+++ b/src/ring_buffer.cpp
@@ -1,0 +1,227 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+#include <unistd.h>
+
+#include "ros2_serial_example/ring_buffer.hpp"
+
+namespace ros2_to_serial_bridge
+{
+
+namespace transport
+{
+
+namespace impl
+{
+
+RingBuffer::RingBuffer(size_t capacity)
+{
+    size = capacity + 1;
+    buf = new uint8_t[size];
+    // TODO(clalancette): check for nullptr
+    head = tail = buf;
+}
+
+RingBuffer::~RingBuffer()
+{
+    delete [] buf;
+}
+
+size_t RingBuffer::buffer_size() const
+{
+    return size;
+}
+
+size_t RingBuffer::capacity() const
+{
+    return size - 1;
+}
+
+uint8_t *RingBuffer::end() const
+{
+    return buf + size;
+}
+
+size_t RingBuffer::bytes_free() const
+{
+    if (head >= tail)
+    {
+        return capacity() - (head - tail);
+    }
+
+    return tail - head - 1;
+}
+
+size_t RingBuffer::bytes_used() const
+{
+    return capacity() - bytes_free();
+}
+
+bool RingBuffer::is_full() const
+{
+    return bytes_free() == 0;
+}
+
+bool RingBuffer::is_empty() const
+{
+    return bytes_free() == capacity();
+}
+
+uint8_t *RingBuffer::nextp(uint8_t *p)
+{
+    // Given a ring buffer rb and a pointer to a location within its
+    // contiguous buffer, return the a pointer to the next logical
+    // location in the ring buffer.
+    return buf + ((++p - buf) % buffer_size());
+}
+
+ssize_t RingBuffer::read(int fd)
+{
+    uint8_t *bufend = end();
+    size_t nfree = bytes_free();
+
+    size_t count = bufend - head;
+    ssize_t n = ::read(fd, head, count);
+    if (n > 0)
+    {
+        head += n;
+
+        // wrap?
+        if (head == bufend)
+        {
+            head = buf;
+        }
+
+        // fix up the tail pointer if an overflow occurred
+        if (static_cast<size_t>(n) > nfree)
+        {
+            tail = nextp(head);
+        }
+    }
+
+    return n;
+}
+
+void *RingBuffer::peek(void *dst, size_t count)
+{
+    if (count > bytes_used())
+    {
+        return nullptr;
+    }
+
+    uint8_t *u8dst = static_cast<uint8_t *>(dst);
+    uint8_t *bufend = end();
+    size_t nwritten = 0;
+    uint8_t *tmptail = tail;
+    while (nwritten != count)
+    {
+        size_t n = std::min(static_cast<size_t>(bufend - tmptail), count - nwritten);
+        ::memcpy(u8dst + nwritten, tmptail, n);
+        tmptail += n;
+        nwritten += n;
+
+        // wrap?
+        if (tmptail == bufend)
+        {
+            tmptail = buf;
+        }
+    }
+
+    return tmptail;
+}
+
+void *RingBuffer::memcpy_from(void *dst, size_t count)
+{
+    if (count > bytes_used())
+    {
+        return nullptr;
+    }
+
+    uint8_t *u8dst = static_cast<uint8_t *>(dst);
+    uint8_t *bufend = end();
+    size_t nwritten = 0;
+    while (nwritten != count)
+    {
+        size_t n = std::min(static_cast<size_t>(bufend - tail), count - nwritten);
+        ::memcpy(u8dst + nwritten, tail, n);
+        tail += n;
+        nwritten += n;
+
+        // wrap?
+        if (tail == bufend)
+        {
+          tail = buf;
+        }
+    }
+
+    return tail;
+}
+
+size_t RingBuffer::findseq(uint8_t *seq, size_t seqlen)
+{
+    size_t used = bytes_used();
+    if (used < seqlen)
+    {
+        // There aren't enough bytes in the ring for this sequence, so it
+        // can't possibly contain the entire sequence.
+        return used;
+    }
+
+    if (seqlen > capacity())
+    {
+        // The sequence to look for is larger than we can possibly hold;
+        // this can't work.
+        return used;
+    }
+
+    uint8_t *ringp = tail;
+    uint8_t *seqp = seq;
+    uint8_t *found = nullptr;
+    uint8_t *start = buf + ((tail - buf) % buffer_size());
+
+    while (ringp != head)
+    {
+        if (*ringp == *seqp)
+        {
+            if (found != nullptr && seqp == (seq + seqlen - 1))
+            {
+                // Found it!  Return the start of the sequence
+                return found - start;
+            }
+
+            if (found == nullptr)
+            {
+                found = ringp;
+            }
+            seqp++;
+        }
+        else
+        {
+            found = nullptr;
+        }
+        ringp = nextp(ringp);
+    }
+
+    return used;
+}
+
+}  // namespace impl
+
+}  // namespace transport
+
+}  // namespace ros2_to_serial_bridge

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -1,0 +1,627 @@
+#include <gtest/gtest.h>
+
+#include <linux/memfd.h>
+
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "ros2_serial_example/ring_buffer.hpp"
+
+/// HELPERS
+
+static inline int memfd_create(const char *name, unsigned int flags)
+{
+    return syscall(__NR_memfd_create, name, flags);
+}
+
+int setup_memfd(const std::string & name)
+{
+    int fd = memfd_create(name.c_str(), MFD_CLOEXEC);
+    if (fd < 0)
+    {
+        return -1;
+    }
+
+    // The RingBuffer class essentially assumes that this file descriptor
+    // is non-blocking
+    if (::fcntl(fd, F_SETFL, O_NONBLOCK) != 0)
+    {
+        ::close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+// Add some additional data to the memfd.  After this call the file pointer will
+// be at the start of the new memory.
+int add_to_memfd(int fd, uint8_t *buf, size_t bufsize)
+{
+    off_t offset = ::lseek(fd, 0, SEEK_CUR);
+    if (offset < 0)
+    {
+        return -1;
+    }
+
+    if (::ftruncate(fd, offset + bufsize) != 0)
+    {
+        return -1;
+    }
+
+    if (::lseek(fd, offset, SEEK_SET) != offset)
+    {
+        return -1;
+    }
+
+    if (::write(fd, buf, bufsize) != static_cast<int>(bufsize))
+    {
+        return -1;
+    }
+
+    if (::lseek(fd, offset, SEEK_SET) != offset)
+    {
+        return -1;
+    }
+
+    return bufsize;
+}
+
+// This fixture allows us access to the protected methods of RingBuffer
+class RingBufferFixture : public ros2_to_serial_bridge::transport::impl::RingBuffer, public testing::Test
+{
+public:
+    // We pick a size of 240 bytes for the ring buffer to ensure that we can fill
+    // uint8_t into the buffer for the tests
+    RingBufferFixture() : RingBuffer(240) {}
+};
+
+/// TESTS
+
+TEST_F(RingBufferFixture, empty)
+{
+    ASSERT_EQ(bytes_used(), 0U);
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size);
+    ASSERT_TRUE(is_empty());
+    ASSERT_EQ(head, buf.get());
+    ASSERT_EQ(tail, buf.get());
+}
+
+TEST_F(RingBufferFixture, read)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    uint8_t data[3]{0x0, 0x1, 0x2};
+    ASSERT_EQ(add_to_memfd(fd, data, sizeof(data)), static_cast<int>(sizeof(data)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(data)));
+
+    ASSERT_EQ(bytes_used(), sizeof(data));
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(data));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(data));
+    ASSERT_EQ(tail, buf.get());
+    ASSERT_FALSE(full);
+    uint8_t *bufp = buf.get();
+    ASSERT_EQ(*bufp++, 0x0);
+    ASSERT_EQ(*bufp++, 0x1);
+    ASSERT_EQ(*bufp++, 0x2);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, read_fill)
+{
+    int fd = setup_memfd("ringbuffer_readwrap_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling up *most* of the buffer
+    uint8_t initialbuf[238];
+    for (uint8_t i = 0; i < sizeof(initialbuf); ++i)
+    {
+        initialbuf[i] = i;
+    }
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    ASSERT_EQ(bytes_used(), sizeof(initialbuf));
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(initialbuf));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(initialbuf));
+    ASSERT_EQ(tail, buf.get());
+    ASSERT_FALSE(full);
+
+    // Now exactly fill it
+    uint8_t smallbuf[2]{238, 239};
+    ASSERT_EQ(add_to_memfd(fd, smallbuf, sizeof(smallbuf)), static_cast<int>(sizeof(smallbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(smallbuf)));
+
+    ASSERT_EQ(bytes_used(), sizeof(initialbuf) + sizeof(smallbuf));
+    ASSERT_TRUE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(initialbuf) - sizeof(smallbuf));
+    ASSERT_FALSE(is_empty());
+    ASSERT_TRUE(full);
+
+    uint8_t *bufp = buf.get();
+    for (uint8_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(*bufp, i);
+        bufp++;
+    }
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, read_wrap)
+{
+    int fd = setup_memfd("ringbuffer_readwrap_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling up the entire buffer
+    uint8_t initialbuf[240];
+    for (uint8_t i = 0; i < sizeof(initialbuf); ++i)
+    {
+        initialbuf[i] = i;
+    }
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    ASSERT_EQ(bytes_used(), sizeof(initialbuf));
+    ASSERT_TRUE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(initialbuf));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get());
+    ASSERT_EQ(tail, buf.get());
+    ASSERT_TRUE(full);
+
+    uint8_t *bufp = buf.get();
+    for (uint8_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(*bufp, i);
+        bufp++;
+    }
+
+    // Now overflow
+    uint8_t smallbuf[2]{240, 241};
+    ASSERT_EQ(add_to_memfd(fd, smallbuf, sizeof(smallbuf)), static_cast<int>(sizeof(smallbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(smallbuf)));
+
+    ASSERT_EQ(bytes_used(), size);
+    ASSERT_TRUE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), 0U);
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(smallbuf));
+    ASSERT_EQ(tail, buf.get() + sizeof(smallbuf));
+    ASSERT_TRUE(full);
+
+    bufp = buf.get();
+    ASSERT_EQ(*bufp++, 240);
+    ASSERT_EQ(*bufp++, 241);
+    for (uint8_t i = 2; i < size; ++i)
+    {
+        ASSERT_EQ(*bufp, i);
+        bufp++;
+    }
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, memcpy_from_nullptr)
+{
+    ASSERT_EQ(memcpy_from(nullptr, 10), -1);
+}
+
+TEST_F(RingBufferFixture, memcpy_from_0_count)
+{
+    uint8_t cpybuf[10]{};
+    ASSERT_EQ(memcpy_from(cpybuf, 0), -1);
+}
+
+TEST_F(RingBufferFixture, memcpy_from_not_enough_bytes)
+{
+    // Try to memcpy out 10 bytes
+    uint8_t cpybuf[10]{};
+    ASSERT_EQ(memcpy_from(cpybuf, sizeof(cpybuf)), -1);
+}
+
+TEST_F(RingBufferFixture, memcpy_from_start_buffer)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    uint8_t data[3]{0x0, 0x1, 0x2};
+    ASSERT_EQ(add_to_memfd(fd, data, sizeof(data)), static_cast<int>(sizeof(data)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(data)));
+
+    ASSERT_EQ(bytes_used(), sizeof(data));
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(data));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(data));
+    ASSERT_EQ(tail, buf.get());
+    ASSERT_FALSE(full);
+
+    uint8_t cpybuf[3]{};
+    ASSERT_EQ(memcpy_from(cpybuf, sizeof(cpybuf)), static_cast<ssize_t>(sizeof(cpybuf)));
+    ASSERT_EQ(cpybuf[0], 0x0);
+    ASSERT_EQ(cpybuf[1], 0x1);
+    ASSERT_EQ(cpybuf[2], 0x2);
+
+    ASSERT_EQ(bytes_used(), 0U);
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size);
+    ASSERT_TRUE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(data));
+    ASSERT_EQ(tail, buf.get() + sizeof(data));
+    ASSERT_FALSE(full);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, memcpy_from_full_buffer)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling up the entire buffer
+    uint8_t initialbuf[240];
+    for (uint8_t i = 0; i < sizeof(initialbuf); ++i)
+    {
+        initialbuf[i] = i;
+    }
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    ASSERT_EQ(bytes_used(), sizeof(initialbuf));
+    ASSERT_TRUE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(initialbuf));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get());
+    ASSERT_EQ(tail, buf.get());
+    ASSERT_TRUE(full);
+
+    for (uint8_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(buf[i], i);
+    }
+
+    // Now copy a bit of data out
+    uint8_t cpybuf[3]{};
+    ASSERT_EQ(memcpy_from(cpybuf, sizeof(cpybuf)), static_cast<ssize_t>(sizeof(cpybuf)));
+    ASSERT_EQ(cpybuf[0], 0x0);
+    ASSERT_EQ(cpybuf[1], 0x1);
+    ASSERT_EQ(cpybuf[2], 0x2);
+
+    ASSERT_EQ(bytes_used(), sizeof(initialbuf) - sizeof(cpybuf));
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), sizeof(cpybuf));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get());
+    ASSERT_EQ(tail, buf.get() + sizeof(cpybuf));
+    ASSERT_FALSE(full);
+
+    // Now add in some more data; this should go by the tail pointer now,
+    // causing the loss of some data
+    uint8_t buf2[10];
+    for (uint8_t i = 0; i < sizeof(buf2); ++i)
+    {
+        buf2[i] = i + 10;
+    }
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(buf2)));
+
+    ASSERT_EQ(bytes_used(), size);
+    ASSERT_TRUE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), 0U);
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(buf2));
+    ASSERT_EQ(tail, buf.get() + sizeof(buf2));
+    ASSERT_TRUE(full);
+
+    // Now look at some data again.  This should be the oldest data available,
+    // which in this case is 0xa (we overwrote older data above).
+    uint8_t cpybuf2[3]{};
+    ASSERT_EQ(memcpy_from(cpybuf2, sizeof(cpybuf2)), static_cast<ssize_t>(sizeof(cpybuf2)));
+    ASSERT_EQ(cpybuf2[0], 0xa);
+    ASSERT_EQ(cpybuf2[1], 0xb);
+    ASSERT_EQ(cpybuf2[2], 0xc);
+
+    ASSERT_EQ(bytes_used(), size - sizeof(cpybuf2));
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), sizeof(cpybuf2));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + sizeof(buf2));
+    ASSERT_EQ(tail, buf.get() + sizeof(buf2) + sizeof(cpybuf2));
+    ASSERT_FALSE(full);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, memcpy_wrap)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling up the entire buffer
+    uint8_t initialbuf[240];
+    for (uint8_t i = 0; i < sizeof(initialbuf); ++i)
+    {
+        initialbuf[i] = i;
+    }
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    ASSERT_EQ(bytes_used(), sizeof(initialbuf));
+    ASSERT_TRUE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - sizeof(initialbuf));
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get());
+    ASSERT_EQ(tail, buf.get());
+    ASSERT_TRUE(full);
+
+    for (uint8_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(buf[i], i);
+    }
+
+    // Now copy most of the data out
+    uint8_t cpybuf[238]{};
+    ASSERT_EQ(memcpy_from(cpybuf, sizeof(cpybuf)), static_cast<ssize_t>(sizeof(cpybuf)));
+    for (uint8_t i = 0; i < sizeof(cpybuf); ++i)
+    {
+        ASSERT_EQ(cpybuf[i], i);
+    }
+
+    // Now add in some more data; this should wrap around
+    uint8_t buf2[10];
+    for (uint8_t i = 0; i < sizeof(buf2); ++i)
+    {
+        buf2[i] = i + 10;
+    }
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(buf2)));
+
+    ASSERT_EQ(bytes_used(), 12U);
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), 228U);
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + 10);
+    ASSERT_EQ(tail, buf.get() + 238);
+    ASSERT_FALSE(full);
+
+    // Now look at some data again.  This should be the oldest data available
+    // and wraparound to the beginning.
+    uint8_t cpybuf2[10]{};
+    ASSERT_EQ(memcpy_from(cpybuf2, sizeof(cpybuf2)), static_cast<ssize_t>(sizeof(cpybuf2)));
+    ASSERT_EQ(cpybuf2[0], 238);
+    ASSERT_EQ(cpybuf2[1], 239);
+    ASSERT_EQ(cpybuf2[2], 0xa);
+    ASSERT_EQ(cpybuf2[3], 0xb);
+    ASSERT_EQ(cpybuf2[4], 0xc);
+    ASSERT_EQ(cpybuf2[5], 0xd);
+    ASSERT_EQ(cpybuf2[6], 0xe);
+    ASSERT_EQ(cpybuf2[7], 0xf);
+    ASSERT_EQ(cpybuf2[8], 0x10);
+    ASSERT_EQ(cpybuf2[9], 0x11);
+
+    ASSERT_EQ(bytes_used(), 2U);
+    ASSERT_FALSE(is_full());
+    ASSERT_EQ(size, 240U);
+    ASSERT_EQ(bytes_free(), size - 2);
+    ASSERT_FALSE(is_empty());
+    ASSERT_EQ(head, buf.get() + 10);
+    ASSERT_EQ(tail, buf.get() + 8);
+    ASSERT_FALSE(full);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, findseq_no_bytes)
+{
+    uint8_t seq[]{'>', '>', '>'};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), -1);
+}
+
+TEST_F(RingBufferFixture, findseq_seq_too_large)
+{
+    uint8_t seq[241]{};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), -1);
+}
+
+TEST_F(RingBufferFixture, findseq_simple)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by adding a known sequence to the buffer.
+    uint8_t initialbuf[]{'>', '>', '>'};
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    uint8_t seq[]{'>', '>', '>'};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), 0);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, findseq_wrap)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling most of the buffer.
+    uint8_t initialbuf[238]{};
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    // Now add in the known sequence, which should span 2 bytes at the end
+    // and one byte at the beginning.
+    uint8_t buf2[]{'>', '>', '>'};
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    // This first read will return short because we reach the end of the
+    // buffer, so call it again to get the rest.
+    ASSERT_EQ(read(fd), 2);
+    ASSERT_EQ(read(fd), 1);
+
+    uint8_t seq[]{'>', '>', '>'};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), 237);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, findseq_wrap2)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling most of the buffer.
+    uint8_t initialbuf[239]{};
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    // Now add in the known sequence, which should span 2 bytes at the end
+    // and one byte at the beginning.
+    uint8_t buf2[]{'>', '>', '>'};
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    // This first read will return short because we reach the end of the
+    // buffer, so call it again to get the rest.
+    ASSERT_EQ(read(fd), 1);
+    ASSERT_EQ(read(fd), 2);
+
+    uint8_t seq[]{'>', '>', '>'};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), 237);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, findseq_single_byte)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling most of the buffer.
+    uint8_t initialbuf[239];
+    for (uint8_t i = 0; i < sizeof(initialbuf); ++i)
+    {
+        initialbuf[i] = 0x1;
+    }
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    // Now add in the known sequence, which should span 2 bytes at the end
+    // and one byte at the beginning.
+    uint8_t buf2[1]{};
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    ASSERT_EQ(read(fd), 1);
+
+    uint8_t seq[]{0x0};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), 239);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, findseq_partial)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling most of the buffer.
+    uint8_t initialbuf[12]{};
+    initialbuf[0] = '>';
+    initialbuf[1] = '>';
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    // Now add in the known sequence, which should span 2 bytes at the end
+    // and one byte at the beginning.
+    uint8_t buf2[]{'>', '>', '>'};
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    // This first read will return short because we reach the end of the
+    // buffer, so call it again to get the rest.
+    ASSERT_EQ(read(fd), 3);
+
+    uint8_t seq[]{'>', '>', '>'};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), 12);
+
+    ::close(fd);
+}
+
+// A test for when the *partial* match is wrapped
+TEST_F(RingBufferFixture, findseq_partial_wrap)
+{
+    int fd = setup_memfd("ringbuffer_read_test");
+    ASSERT_GE(fd, 0);
+
+    // Start by filling most of the buffer.
+    uint8_t initialbuf[240]{};
+    initialbuf[239] = '>';
+    ASSERT_EQ(add_to_memfd(fd, initialbuf, sizeof(initialbuf)), static_cast<int>(sizeof(initialbuf)));
+
+    ASSERT_EQ(read(fd), static_cast<ssize_t>(sizeof(initialbuf)));
+
+    // Now add in the rest of the partial sequence, which should wrap to the
+    // beginning.
+    uint8_t buf2[11]{};
+    buf2[0] = '>';
+    ASSERT_EQ(add_to_memfd(fd, buf2, sizeof(buf2)), static_cast<int>(sizeof(buf2)));
+
+    // This first read will return short because we reach the end of the
+    // buffer, so call it again to get the rest.
+    ASSERT_EQ(read(fd), 11);
+
+    // Now add in the real sequence we want to find.
+    uint8_t buf3[]{'>', '>', '>'};
+    ASSERT_EQ(add_to_memfd(fd, buf3, sizeof(buf3)), static_cast<int>(sizeof(buf3)));
+
+    // This first read will return short because we reach the end of the
+    // buffer, so call it again to get the rest.
+    ASSERT_EQ(read(fd), 3);
+
+    uint8_t seq[]{'>', '>', '>'};
+    ASSERT_EQ(findseq(seq, sizeof(seq)), 237);
+
+    ::close(fd);
+}
+
+TEST_F(RingBufferFixture, peek_not_enough_bytes)
+{
+    uint8_t out[5]{};
+    ASSERT_EQ(peek(out, sizeof(out)), -1);
+}


### PR DESCRIPTION
And while we are at it, fix the ring buffer to be much more understandable.  Things done in here:

1.  Split the ring buffer into a separate source file and library (commit 2b65ab4).
2.  Write tests for the ring buffer, testing out various aspects.  Along the way, figured out that the previous implementation was very difficult to understand (and possibly buggy), so clean up the ring buffer to be much easier to understand, and add the tests to ensure it stays that way.
3.  Add in documentation for the ring buffer.