### PR TITLE
Allow the ring buffer size to be configured.

### DIFF
--- a/include/ros2_serial_example/transporter.hpp
+++ b/include/ros2_serial_example/transporter.hpp
@@ -56,7 +56,7 @@ namespace transport
 class Transporter
 {
 public:
-    explicit Transporter(const std::string & _protocol);
+    explicit Transporter(const std::string & _protocol, size_t ring_buffer_size);
     virtual ~Transporter();
 
     virtual int init() {return 0;}

--- a/include/ros2_serial_example/uart_transporter.hpp
+++ b/include/ros2_serial_example/uart_transporter.hpp
@@ -54,7 +54,11 @@ namespace transport
 class UARTTransporter final : public Transporter
 {
 public:
-    UARTTransporter(const std::string & _uart_name, const std::string & _protocol, uint32_t _baudrate, uint32_t _poll_ms);
+    UARTTransporter(const std::string & _uart_name,
+                    const std::string & _protocol,
+                    uint32_t _baudrate,
+                    uint32_t _poll_ms,
+                    size_t _ring_buffer_size);
     virtual ~UARTTransporter();
 
     int init() override;
@@ -67,7 +71,7 @@ private:
 
     std::string uart_name{};
     uint32_t baudrate;
-    uint32_t poll_ms;
+    uint32_t read_poll_ms;
     int uart_fd{-1};
     uint32_t write_timeout_us{20};
     struct pollfd poll_fd[1] = {};

--- a/src/dummy_serial.cpp
+++ b/src/dummy_serial.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    std::unique_ptr<ros2_to_serial_bridge::transport::Transporter> transporter = std::make_unique<ros2_to_serial_bridge::transport::UARTTransporter>(device, serial_protocol, baudrate, 100);
+    std::unique_ptr<ros2_to_serial_bridge::transport::Transporter> transporter = std::make_unique<ros2_to_serial_bridge::transport::UARTTransporter>(device, serial_protocol, baudrate, 100, 8192);
 
     if (transporter->init() < 0)
     {

--- a/src/ros2_to_serial_bridge.cpp
+++ b/src/ros2_to_serial_bridge.cpp
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
         baudrate = 0;
     }
 
-    std::shared_ptr<ros2_to_serial_bridge::transport::Transporter> transporter = std::make_shared<ros2_to_serial_bridge::transport::UARTTransporter>(device, serial_protocol, baudrate, 100);
+    std::shared_ptr<ros2_to_serial_bridge::transport::Transporter> transporter = std::make_shared<ros2_to_serial_bridge::transport::UARTTransporter>(device, serial_protocol, baudrate, 100, 8192);
 
     if (transporter->init() < 0)
     {

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -94,7 +94,7 @@ uint16_t const crc16_table[256] = {
     0x8201, 0x42C0, 0x4380, 0x8341, 0x4100, 0x81C1, 0x8081, 0x4040
 };
 
-Transporter::Transporter(const std::string & _protocol) : ringbuf(1024)
+Transporter::Transporter(const std::string & _protocol, size_t ring_buffer_size) : ringbuf(ring_buffer_size)
 {
     if (_protocol == "px4")
     {


### PR DESCRIPTION
That way, users of the transporter class can trade off
memory usage vs. maximum size they want to be able to transfer.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>