### PR TITLE
More clang-tidy fixes.

### DIFF
--- a/include/ros2_serial_example/publisher.hpp
+++ b/include/ros2_serial_example/publisher.hpp
@@ -28,6 +28,14 @@ namespace pubsub
 class Publisher
 {
 public:
+    Publisher() {};
+    virtual ~Publisher() {};
+
+    Publisher(Publisher const &) = delete;
+    Publisher& operator=(Publisher const &) = delete;
+    Publisher(Publisher &&) = delete;
+    Publisher& operator=(Publisher &&) = delete;
+
     virtual void dispatch(uint8_t *data_buffer, ssize_t length) = 0;
 };
 

--- a/include/ros2_serial_example/subscription_impl.hpp
+++ b/include/ros2_serial_example/subscription_impl.hpp
@@ -42,7 +42,7 @@ public:
     explicit Subscription_impl(const std::shared_ptr<rclcpp::Node> & node,
                                topic_id_size_t mapping,
                                const std::string & name,
-                               const std::shared_ptr<transport::Transporter> & transporter,
+                               transport::Transporter * transporter,
                                std::function<size_t(const T &, size_t)> get_size,
                                std::function<bool(const T &, eprosima::fastcdr::Cdr &)> serialize) : Subscription()
     {

--- a/src/ros2_to_serial_bridge.cpp
+++ b/src/ros2_to_serial_bridge.cpp
@@ -59,7 +59,7 @@ static void params_usage()
 }
 
 static std::unique_ptr<ros2_to_serial_bridge::pubsub::ROS2Topics> parse_node_parameters_for_topics(const std::shared_ptr<rclcpp::Node> & node,
-                                                                    std::shared_ptr<ros2_to_serial_bridge::transport::Transporter> transporter)
+                                                                                                   ros2_to_serial_bridge::transport::Transporter * transporter)
 {
     // Now we go through the YAML file containing our parameters, looking for
     // parameters of the form:
@@ -140,8 +140,8 @@ static std::unique_ptr<ros2_to_serial_bridge::pubsub::ROS2Topics> parse_node_par
     try
     {
         ros2_topics = std::make_unique<ros2_to_serial_bridge::pubsub::ROS2Topics>(node,
-                                                   topic_names_and_serialization,
-                                                   transporter);
+                                                                                  topic_names_and_serialization,
+                                                                                  transporter);
     }
     catch (const std::runtime_error & err)
     {
@@ -203,14 +203,14 @@ int main(int argc, char *argv[])
         baudrate = 0;
     }
 
-    std::shared_ptr<ros2_to_serial_bridge::transport::Transporter> transporter = std::make_shared<ros2_to_serial_bridge::transport::UARTTransporter>(device, serial_protocol, baudrate, 100, 8192);
+    std::unique_ptr<ros2_to_serial_bridge::transport::Transporter> transporter = std::make_unique<ros2_to_serial_bridge::transport::UARTTransporter>(device, serial_protocol, baudrate, 100, 8192);
 
     if (transporter->init() < 0)
     {
         return 1;
     }
 
-    std::shared_ptr<ros2_to_serial_bridge::pubsub::ROS2Topics> ros2_topics = parse_node_parameters_for_topics(node, transporter);
+    std::shared_ptr<ros2_to_serial_bridge::pubsub::ROS2Topics> ros2_topics = parse_node_parameters_for_topics(node, transporter.get());
     if (ros2_topics == nullptr)
     {
         return 2;

--- a/templates/pub_sub_type.cpp.em
+++ b/templates/pub_sub_type.cpp.em
@@ -43,7 +43,7 @@ std::unique_ptr<Publisher> @(ros2_type.ns)_@(ros2_type.lower_type)_pub_factory(c
   return std::make_unique<Publisher_impl<@(ros2_type.ns)::msg::@(ros2_type.ros_type)>>(node, topic, des);
 }
 
-std::unique_ptr<Subscription> @(ros2_type.ns)_@(ros2_type.lower_type)_sub_factory(const std::shared_ptr<rclcpp::Node> node, topic_id_size_t serial_mapping, const std::string & topic, std::shared_ptr<ros2_to_serial_bridge::transport::Transporter> transporter)
+std::unique_ptr<Subscription> @(ros2_type.ns)_@(ros2_type.lower_type)_sub_factory(const std::shared_ptr<rclcpp::Node> node, topic_id_size_t serial_mapping, const std::string & topic, ros2_to_serial_bridge::transport::Transporter * transporter)
 {
   typedef size_t (*getsize_t)(const @(ros2_type.ns)::msg::@(ros2_type.ros_type) &, size_t);
   getsize_t getsize = @(ros2_type.ns)::msg::typesupport_fastrtps_cpp::get_serialized_size;

--- a/templates/pub_sub_type.hpp.em
+++ b/templates/pub_sub_type.hpp.em
@@ -31,7 +31,7 @@ namespace pubsub
 {
 
 std::unique_ptr<Publisher> @(ros2_type.ns)_@(ros2_type.lower_type)_pub_factory(const std::shared_ptr<rclcpp::Node> node, const std::string & topic);
-std::unique_ptr<Subscription> @(ros2_type.ns)_@(ros2_type.lower_type)_sub_factory(const std::shared_ptr<rclcpp::Node> node, topic_id_size_t serial_mapping, const std::string & topic, std::shared_ptr<ros2_to_serial_bridge::transport::Transporter> transporter);
+std::unique_ptr<Subscription> @(ros2_type.ns)_@(ros2_type.lower_type)_sub_factory(const std::shared_ptr<rclcpp::Node> node, topic_id_size_t serial_mapping, const std::string & topic, ros2_to_serial_bridge::transport::Transporter * transporter);
 
 }  // namespace pubsub
 }  // namespace ros2_to_serial_bridge


### PR DESCRIPTION
1.  Make sure to add deleted move, copy, and assignment constructors
for Publisher class
2.  Pass a transporter pointer (not the shared_ptr) into the functions;
this avoids a copy of the shared_ptr structure
3.  Change the generated code to put the map of topic types to
function pointers in an in-class map instead of a static one that
could throw an exception we can't catch

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>