### PR TITLE
Rename {Publisher,Subscriber}_impl -> {Publisher,Subscriber}

### DIFF
--- a/include/ros2_serial_example/publisher_impl.hpp
+++ b/include/ros2_serial_example/publisher_impl.hpp
@@ -34,11 +34,11 @@ namespace pubsub
 {
 
 template<typename T>
-class Publisher_impl final : public Publisher
+class PublisherImpl final : public Publisher
 {
 public:
-    explicit Publisher_impl(const std::shared_ptr<rclcpp::Node> & node, const std::string & name,
-                            std::function<bool(eprosima::fastcdr::Cdr &, T &)> des) : deserialize(des)
+    explicit PublisherImpl(const std::shared_ptr<rclcpp::Node> & node, const std::string & name,
+                           std::function<bool(eprosima::fastcdr::Cdr &, T &)> des) : deserialize(des)
     {
         pub = node->create_publisher<T>(name);
     }

--- a/include/ros2_serial_example/subscription_impl.hpp
+++ b/include/ros2_serial_example/subscription_impl.hpp
@@ -36,15 +36,15 @@ namespace pubsub
 {
 
 template<typename T>
-class Subscription_impl final : public Subscription
+class SubscriptionImpl final : public Subscription
 {
 public:
-    explicit Subscription_impl(const std::shared_ptr<rclcpp::Node> & node,
-                               topic_id_size_t mapping,
-                               const std::string & name,
-                               transport::Transporter * transporter,
-                               std::function<size_t(const T &, size_t)> get_size,
-                               std::function<bool(const T &, eprosima::fastcdr::Cdr &)> serialize) : Subscription()
+    explicit SubscriptionImpl(const std::shared_ptr<rclcpp::Node> & node,
+                              topic_id_size_t mapping,
+                              const std::string & name,
+                              transport::Transporter * transporter,
+                              std::function<size_t(const T &, size_t)> get_size,
+                              std::function<bool(const T &, eprosima::fastcdr::Cdr &)> serialize) : Subscription()
     {
         size_t headlen = transporter->get_header_length();
         serial_mapping = mapping;

--- a/templates/pub_sub_type.cpp.em
+++ b/templates/pub_sub_type.cpp.em
@@ -40,7 +40,7 @@ std::unique_ptr<Publisher> @(ros2_type.ns)_@(ros2_type.lower_type)_pub_factory(c
 {
   typedef bool (*des_t)(eprosima::fastcdr::Cdr &, @(ros2_type.ns)::msg::@(ros2_type.ros_type) &);
   des_t des = @(ros2_type.ns)::msg::typesupport_fastrtps_cpp::cdr_deserialize;
-  return std::make_unique<Publisher_impl<@(ros2_type.ns)::msg::@(ros2_type.ros_type)>>(node, topic, des);
+  return std::make_unique<PublisherImpl<@(ros2_type.ns)::msg::@(ros2_type.ros_type)>>(node, topic, des);
 }
 
 std::unique_ptr<Subscription> @(ros2_type.ns)_@(ros2_type.lower_type)_sub_factory(const std::shared_ptr<rclcpp::Node> node, topic_id_size_t serial_mapping, const std::string & topic, ros2_to_serial_bridge::transport::Transporter * transporter)
@@ -50,7 +50,7 @@ std::unique_ptr<Subscription> @(ros2_type.ns)_@(ros2_type.lower_type)_sub_factor
   typedef bool (*ser_t)(const @(ros2_type.ns)::msg::@(ros2_type.ros_type) &, eprosima::fastcdr::Cdr &);
   ser_t ser = @(ros2_type.ns)::msg::typesupport_fastrtps_cpp::cdr_serialize;
 
-  return std::make_unique<Subscription_impl<@(ros2_type.ns)::msg::@(ros2_type.ros_type)>>(node, serial_mapping, topic, transporter, getsize, ser);
+  return std::make_unique<SubscriptionImpl<@(ros2_type.ns)::msg::@(ros2_type.ros_type)>>(node, serial_mapping, topic, transporter, getsize, ser);
 }
 
 }  // namespace pubsub


### PR DESCRIPTION
Just keep with CamelCase for class names.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>