### PR TITLE
Get rid of problematic optimization for Transporter write()

### DIFF
--- a/include/ros2_serial_example/subscription_impl.hpp
+++ b/include/ros2_serial_example/subscription_impl.hpp
@@ -46,13 +46,12 @@ public:
                               std::function<size_t(const T &, size_t)> get_size,
                               std::function<bool(const T &, eprosima::fastcdr::Cdr &)> serialize) : Subscription()
     {
-        size_t headlen = transporter->get_header_length();
         serial_mapping_ = mapping;
-        auto callback = [node, mapping, transporter, get_size, serialize, headlen](const typename T::SharedPtr msg) -> void
+        auto callback = [node, mapping, transporter, get_size, serialize](const typename T::SharedPtr msg) -> void
         {
             size_t serialized_size = get_size(*(msg.get()), 0);
-            std::unique_ptr<uint8_t[]> data_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[headlen + serialized_size]);
-            eprosima::fastcdr::FastBuffer cdrbuffer(reinterpret_cast<char *>(data_buffer.get()) + headlen, serialized_size);
+            std::unique_ptr<uint8_t[]> data_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[serialized_size]);
+            eprosima::fastcdr::FastBuffer cdrbuffer(reinterpret_cast<char *>(data_buffer.get()), serialized_size);
             eprosima::fastcdr::Cdr scdr(cdrbuffer);
             serialize(*(msg.get()), scdr);
             if (transporter->write(mapping, data_buffer.get(), scdr.getSerializedDataLength()) < 0)

--- a/include/ros2_serial_example/transporter.hpp
+++ b/include/ros2_serial_example/transporter.hpp
@@ -57,7 +57,7 @@ namespace transport
 class Transporter
 {
 public:
-    explicit Transporter(const std::string & _protocol, size_t ring_buffer_size);
+    explicit Transporter(const std::string & protocol, size_t ring_buffer_size);
     virtual ~Transporter();
 
     Transporter(Transporter const &) = delete;
@@ -83,9 +83,6 @@ public:
      */
     ssize_t write(topic_id_size_t topic_ID, uint8_t *buffer, size_t data_length);
 
-    /** Get the Length of struct Header to make headroom for the size of struct Header along with payload */
-    size_t get_header_length();
-
 protected:
     virtual ssize_t node_read() = 0;
     virtual ssize_t node_write(void *buffer, size_t len) = 0;
@@ -101,6 +98,9 @@ private:
         PX4,
         COBS,
     };
+
+    /** Get the Length of struct Header */
+    size_t get_header_length();
 
     ssize_t find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *out_buffer, size_t buffer_len);
 

--- a/src/dummy_serial.cpp
+++ b/src/dummy_serial.cpp
@@ -137,8 +137,6 @@ int main(int argc, char *argv[])
 
     std::thread read_thread(read_thread_func, transporter.get());
 
-    size_t headlen = transporter->get_header_length();
-
     // We use a unique_ptr here both to make this a heap allocation and to quiet
     // non-owning pointer warnings from clang-tidy
     std::unique_ptr<uint8_t[]> data_buffer(new uint8_t[BUFFER_SIZE]);
@@ -147,7 +145,7 @@ int main(int argc, char *argv[])
     while (running != 0)
     {
         // With the current configuration, topic 9 is a std_msgs/String topic.
-        eprosima::fastcdr::FastBuffer cdrbuffer(reinterpret_cast<char *>(data_buffer.get()) + headlen, BUFFER_SIZE - headlen);
+        eprosima::fastcdr::FastBuffer cdrbuffer(reinterpret_cast<char *>(data_buffer.get()), BUFFER_SIZE);
         eprosima::fastcdr::Cdr scdr(cdrbuffer);
         scdr << "aa";
         if (transporter->write(9, data_buffer.get(), scdr.getSerializedDataLength()) < 0)
@@ -156,7 +154,7 @@ int main(int argc, char *argv[])
         }
 
         // With the current configuration, topic 12 is a std_msgs/UInt16 topic.
-        eprosima::fastcdr::FastBuffer cdrbuffer2(reinterpret_cast<char *>(data_buffer2.get()) + headlen, BUFFER_SIZE - headlen);
+        eprosima::fastcdr::FastBuffer cdrbuffer2(reinterpret_cast<char *>(data_buffer2.get()), BUFFER_SIZE);
         eprosima::fastcdr::Cdr scdr2(cdrbuffer2);
         scdr2 << 256;
         if (transporter->write(12, data_buffer2.get(), scdr2.getSerializedDataLength()) < 0)


### PR DESCRIPTION
We inherited an optimization from PX4 where they attempt to
avoid copies by having the caller of transporter.write()
allocate the correct number of header bytes.  However, this
has a couple of different problems:

1.  It doesn't actually work if we use COBS, since there is
some size amplification anyway
2.  It is a very non-intuitive interface for the caller

Because it isn't a huge bottleneck, just remove the optimization
for now and allow the user to just pass their payload with
write() taking care of adding a header (this involves some
copies).  If it turns out that this is really a bottleneck in
the future, there are a couple of different ways that we could
improve the performance here:

1.  The CRC16 calculation over the payload has to visit every
byte, so we could think about combining crc16 calculation with
a copy into the new buffer.  This doesn't get rid of the allocation,
but it does mean we only iterate over the bytes once.
2.  We could alleviate concern 1 above by having another method
in Transporter() that returned the worst-case size needed.  This
would preserve the performance benefits while allowing it to work
with COBS.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>