### PR TITLE
Remove RingBuffer is_full() method.

### DIFF
--- a/include/ros2_serial_example/ring_buffer.hpp
+++ b/include/ros2_serial_example/ring_buffer.hpp
@@ -131,13 +131,6 @@ public:
      */
     size_t bytes_used() const;
 
-    /**
-     * Returns whether the ring buffer is currently full.
-     *
-     * @returns true if the ring buffer is full, false otherwise.
-     */
-    bool is_full() const;
-
 protected:
     /**
      * Get a pointer to the end of the ring buffer.

--- a/src/ring_buffer.cpp
+++ b/src/ring_buffer.cpp
@@ -64,11 +64,6 @@ size_t RingBuffer::bytes_used() const
     return size_ + head_ - tail_;
 }
 
-bool RingBuffer::is_full() const
-{
-    return full_;
-}
-
 bool RingBuffer::is_empty() const
 {
     return (!full_ && (head_ == tail_));

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -181,16 +181,7 @@ ssize_t Transporter::find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *o
 
         if (offset < 0)
         {
-            // We didn't find the sequence; if the ring buffer is full, throw away one
-            // byte to make room.
-            if (ringbuf_.is_full())
-            {
-                uint8_t dummy;
-                if (ringbuf_.memcpy_from(&dummy, 1) < 0)
-                {
-                    throw std::runtime_error("Failed to clear out single PX4 byte from ring buffer");
-                }
-            }
+            // We didn't find the sequence, so just return
             return 0;
         }
 
@@ -287,16 +278,7 @@ ssize_t Transporter::find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *o
 
         if (offset < 0)
         {
-            // We didn't find the sequence; if the ring buffer is full, throw away one
-            // byte to make room for new bytes.
-            if (ringbuf_.is_full())
-            {
-                uint8_t dummy;
-                if (ringbuf_.memcpy_from(&dummy, 1) < 0)
-                {
-                    throw std::runtime_error("Failed to clear out single COBS byte from ring buffer");
-                }
-            }
+            // We didn't find the sequence, so just return
             return 0;
         }
 
@@ -393,15 +375,6 @@ ssize_t Transporter::read(topic_id_size_t *topic_ID, uint8_t *out_buffer, size_t
         if (len > 0)
         {
             return len;
-        }
-    }
-
-    if (ringbuf_.is_full())
-    {
-        uint8_t dummy;
-        if (ringbuf_.memcpy_from(&dummy, 1) < 0)
-        {
-            throw std::runtime_error("Failed to clear out single byte to read into");
         }
     }
 

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -89,12 +89,12 @@ protected:
 TEST_F(RingBufferFixture, empty)
 {
     ASSERT_EQ(bytes_used(), 0U);
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_);
     ASSERT_TRUE(is_empty());
     ASSERT_EQ(head_, buf_.get());
     ASSERT_EQ(tail_, buf_.get());
+    ASSERT_FALSE(full_);
 }
 
 TEST_F(RingBufferFixture, read)
@@ -105,7 +105,6 @@ TEST_F(RingBufferFixture, read)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(data)));
 
     ASSERT_EQ(bytes_used(), sizeof(data));
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(data));
     ASSERT_FALSE(is_empty());
@@ -131,7 +130,6 @@ TEST_F(RingBufferFixture, read_fill)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(initialbuf)));
 
     ASSERT_EQ(bytes_used(), sizeof(initialbuf));
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(initialbuf));
     ASSERT_FALSE(is_empty());
@@ -146,7 +144,6 @@ TEST_F(RingBufferFixture, read_fill)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(smallbuf)));
 
     ASSERT_EQ(bytes_used(), sizeof(initialbuf) + sizeof(smallbuf));
-    ASSERT_TRUE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(initialbuf) - sizeof(smallbuf));
     ASSERT_FALSE(is_empty());
@@ -173,7 +170,6 @@ TEST_F(RingBufferFixture, read_wrap)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(initialbuf)));
 
     ASSERT_EQ(bytes_used(), sizeof(initialbuf));
-    ASSERT_TRUE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(initialbuf));
     ASSERT_FALSE(is_empty());
@@ -195,7 +191,6 @@ TEST_F(RingBufferFixture, read_wrap)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(smallbuf)));
 
     ASSERT_EQ(bytes_used(), size_);
-    ASSERT_TRUE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), 0U);
     ASSERT_FALSE(is_empty());
@@ -239,7 +234,6 @@ TEST_F(RingBufferFixture, memcpy_from_start_buffer)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(data)));
 
     ASSERT_EQ(bytes_used(), sizeof(data));
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(data));
     ASSERT_FALSE(is_empty());
@@ -254,7 +248,6 @@ TEST_F(RingBufferFixture, memcpy_from_start_buffer)
     ASSERT_EQ(cpybuf[2], 0x2);
 
     ASSERT_EQ(bytes_used(), 0U);
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_);
     ASSERT_TRUE(is_empty());
@@ -276,7 +269,6 @@ TEST_F(RingBufferFixture, memcpy_from_full_buffer)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(initialbuf)));
 
     ASSERT_EQ(bytes_used(), sizeof(initialbuf));
-    ASSERT_TRUE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(initialbuf));
     ASSERT_FALSE(is_empty());
@@ -297,7 +289,6 @@ TEST_F(RingBufferFixture, memcpy_from_full_buffer)
     ASSERT_EQ(cpybuf[2], 0x2);
 
     ASSERT_EQ(bytes_used(), sizeof(initialbuf) - sizeof(cpybuf));
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), sizeof(cpybuf));
     ASSERT_FALSE(is_empty());
@@ -317,7 +308,6 @@ TEST_F(RingBufferFixture, memcpy_from_full_buffer)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(buf2)));
 
     ASSERT_EQ(bytes_used(), size_);
-    ASSERT_TRUE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), 0U);
     ASSERT_FALSE(is_empty());
@@ -334,7 +324,6 @@ TEST_F(RingBufferFixture, memcpy_from_full_buffer)
     ASSERT_EQ(cpybuf2[2], 0xc);
 
     ASSERT_EQ(bytes_used(), size_ - sizeof(cpybuf2));
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), sizeof(cpybuf2));
     ASSERT_FALSE(is_empty());
@@ -356,7 +345,6 @@ TEST_F(RingBufferFixture, memcpy_wrap)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(initialbuf)));
 
     ASSERT_EQ(bytes_used(), sizeof(initialbuf));
-    ASSERT_TRUE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - sizeof(initialbuf));
     ASSERT_FALSE(is_empty());
@@ -388,7 +376,6 @@ TEST_F(RingBufferFixture, memcpy_wrap)
     ASSERT_EQ(read(memfd_), static_cast<ssize_t>(sizeof(buf2)));
 
     ASSERT_EQ(bytes_used(), 12U);
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), 228U);
     ASSERT_FALSE(is_empty());
@@ -412,7 +399,6 @@ TEST_F(RingBufferFixture, memcpy_wrap)
     ASSERT_EQ(cpybuf2[9], 0x11);
 
     ASSERT_EQ(bytes_used(), 2U);
-    ASSERT_FALSE(is_full());
     ASSERT_EQ(size_, 240U);
     ASSERT_EQ(bytes_free(), size_ - 2);
     ASSERT_FALSE(is_empty());


### PR DESCRIPTION
Since the ring buffer automatically overwrites old data, there
was no reason to clear out space in the ring if we didn't find
a sequence we were looking for.  This leads to us being able
to remove the is_full() method completely, since now nothing
needs to do that.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>