### PR TITLE
Make sure to add a virtual destructor to Subscription.

### DIFF
--- a/include/ros2_serial_example/subscription.hpp
+++ b/include/ros2_serial_example/subscription.hpp
@@ -26,6 +26,14 @@ namespace pubsub
 class Subscription
 {
 public:
+    Subscription() {}
+    virtual ~Subscription() {}
+
+    Subscription(Subscription const &) = delete;
+    Subscription& operator=(Subscription const &) = delete;
+    Subscription(Subscription &&) = delete;
+    Subscription& operator=(Subscription &&) = delete;
+
     topic_id_size_t get_serial_mapping() const
     {
         return serial_mapping_;

--- a/templates/ros2_topics.hpp.em
+++ b/templates/ros2_topics.hpp.em
@@ -131,6 +131,7 @@ public:
             serial_to_pub_[topic_ID]->dispatch(data_buffer, length);
         }
     }
+
 private:
     std::map<topic_id_size_t, std::unique_ptr<Publisher>> serial_to_pub_;
     std::vector<std::unique_ptr<Subscription>> serial_subs_;


### PR DESCRIPTION
Otherwise, SubscriptionImpl's destructor wouldn't be called
and properly cleanup the subscriptions.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>