### PR TITLE
Reduce the CPU usage of the bridge.

### DIFF
--- a/src/ros2_to_serial_bridge.cpp
+++ b/src/ros2_to_serial_bridge.cpp
@@ -220,7 +220,11 @@ int main(int argc, char *argv[])
 
     std::thread read_thread(read_thread_func, transporter.get(), ros2_topics.get());
 
-    rclcpp::WallRate loop_rate(1000);
+    // This loop rate translates linearly into the latency to take data from
+    // the ROS 2 network and output it to the serial port.  250Hz is a decent
+    // balance between CPU time and latency (4ms), but if you are willing to
+    // sacrifice CPU time to get better latency, increase this to 1000 or more.
+    rclcpp::WallRate loop_rate(250);
     while (rclcpp::ok() && running != 0)
     {
         // Process ROS 2 -> serial data (via callbacks)


### PR DESCRIPTION
By waking up every 1 ms to check for ROS work, we were
using a lot of CPU time.  Reduce it to 4 ms, which has a
corresponding linear decrease in the amount of CPU time we
use.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>