### PR TITLE
Make sure to zero out the data_buffer when allocating.

### DIFF
--- a/include/ros2_serial_example/subscription_impl.hpp
+++ b/include/ros2_serial_example/subscription_impl.hpp
@@ -71,7 +71,7 @@ public:
         auto callback = [node, mapping, transporter, get_size, serialize](const typename T::SharedPtr msg) -> void
         {
             size_t serialized_size = get_size(*(msg.get()), 0);
-            std::unique_ptr<uint8_t[]> data_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[serialized_size]);
+            std::unique_ptr<uint8_t[]> data_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[serialized_size]{});
             eprosima::fastcdr::FastBuffer cdrbuffer(reinterpret_cast<char *>(data_buffer.get()), serialized_size);
             eprosima::fastcdr::Cdr scdr(cdrbuffer);
             serialize(*(msg.get()), scdr);


### PR DESCRIPTION
It seems that Fast-CDR doesn't always touch all of the bytes
it uses for serializing, which means that we can sometimes
touch uninitialized data (as pointed out by valgrind).  Make
sure to zero out all of the serialized data when we allocate
it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>