### PR TITLE
Crystal support

### DIFF
--- a/ros2_serial_example/include/ros2_serial_example/transporter.hpp
+++ b/ros2_serial_example/include/ros2_serial_example/transporter.hpp
@@ -246,8 +246,8 @@ protected:
      *                      valid if the return value > 0).
      * @param[out] out_buffer The buffer to receive the payload into.
      * @param[in] buffer_len The maximum buffer length to receive the payload into.
-     * @returns The payload on success, 0 if there are no messages available,
-     *          and < 0 if the payload couldn't fit into the given buffer.
+     * @returns The payload length on success (which may be 0, and < 0 if a
+     *          valid message could not be returned.
      * @throws std::runtime_error If an internal contract was not fulfilled;
      *         this is typically fatal.
      */

--- a/ros2_serial_example/src/dummy_serial.cpp
+++ b/ros2_serial_example/src/dummy_serial.cpp
@@ -64,7 +64,7 @@ void read_thread_func(ros2_to_serial_bridge::transport::Transporter * transporte
     while (running != 0)
     {
         // Process data coming over serial
-        if ((length = transporter->read(&topic_ID, data_buffer.get(), BUFFER_SIZE)) > 0)
+        if ((length = transporter->read(&topic_ID, data_buffer.get(), BUFFER_SIZE)) >= 0)
         {
             if (topic_ID == 0)
             {

--- a/ros2_serial_example/src/transporter.cpp
+++ b/ros2_serial_example/src/transporter.cpp
@@ -116,7 +116,7 @@ Transporter::~Transporter()
 
 uint16_t Transporter::crc16_byte(uint16_t crc, uint8_t data)
 {
-    return (crc >> 8) ^ crc16_table[(crc ^ data) & 0xff];
+    return static_cast<uint8_t>(crc >> 8U) ^ crc16_table[static_cast<uint8_t>(crc ^ data)];
 }
 
 uint16_t Transporter::crc16(uint8_t const *buffer, size_t len)
@@ -218,7 +218,7 @@ ssize_t Transporter::find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *o
 
         PX4Header *header = reinterpret_cast<PX4Header *>(headerbuf.get());
 
-        uint32_t payload_len = (static_cast<uint32_t>(header->payload_len_h) << 8) | header->payload_len_l;
+        uint16_t payload_len = static_cast<uint16_t>(static_cast<uint16_t>(header->payload_len_h) << 8U) | header->payload_len_l;
 
         if (buffer_len < payload_len)
         {
@@ -249,7 +249,7 @@ ssize_t Transporter::find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *o
             throw std::runtime_error("Unexpected ring buffer failure");
         }
 
-        uint16_t read_crc = (static_cast<uint16_t>(header->crc_h) << 8) | header->crc_l;
+        uint16_t read_crc = static_cast<uint16_t>(static_cast<uint16_t>(header->crc_h) << 8U) | header->crc_l;
         uint16_t calc_crc = crc16(out_buffer, payload_len);
 
         ssize_t len;
@@ -321,7 +321,7 @@ ssize_t Transporter::find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *o
         }
 
         COBSHeader *header = reinterpret_cast<COBSHeader *>(unstuffed_buffer.get());
-        uint32_t payload_len = (static_cast<uint32_t>(header->payload_len_h) << 8) | header->payload_len_l;
+        uint16_t payload_len = static_cast<uint16_t>(static_cast<uint16_t>(header->payload_len_h) << 8U) | header->payload_len_l;
 
         if ((unstuffed_size - header_len) < payload_len)
         {
@@ -336,7 +336,7 @@ ssize_t Transporter::find_and_copy_message(topic_id_size_t *topic_ID, uint8_t *o
             return -EMSGSIZE;
         }
 
-        uint16_t read_crc = (static_cast<uint16_t>(header->crc_h) << 8) | header->crc_l;
+        uint16_t read_crc = static_cast<uint16_t>(static_cast<uint16_t>(header->crc_h) << 8U) | header->crc_l;
         uint16_t calc_crc = crc16(unstuffed_buffer.get() + header_len, payload_len);
 
         ssize_t len;
@@ -492,10 +492,10 @@ ssize_t Transporter::write(topic_id_size_t topic_ID, uint8_t const *buffer, size
 
         header.topic_ID = topic_ID;
         header.seq = seq_++;
-        header.payload_len_h = (data_length >> 8) & 0xff;
-        header.payload_len_l = data_length & 0xff;
-        header.crc_h = (crc >> 8) & 0xff;
-        header.crc_l = crc & 0xff;
+        header.payload_len_h = (data_length >> 8U) & 0xffU;
+        header.payload_len_l = data_length & 0xffU;
+        header.crc_h = static_cast<uint8_t>(crc >> 8U);
+        header.crc_l = crc & 0xffU;
 
         write_length = header_len + data_length;
         write_buf = std::unique_ptr<uint8_t[]>(new uint8_t[write_length]);
@@ -520,10 +520,10 @@ ssize_t Transporter::write(topic_id_size_t topic_ID, uint8_t const *buffer, size
 
         header.topic_ID = topic_ID;
         // This is the payload length without the header and before stuffing
-        header.payload_len_h = (data_length >> 8) & 0xff;
-        header.payload_len_l = data_length & 0xff;
-        header.crc_h = (crc >> 8) & 0xff;
-        header.crc_l = crc & 0xff;
+        header.payload_len_h = (data_length >> 8U) & 0xffU;
+        header.payload_len_l = data_length & 0xffU;
+        header.crc_h = static_cast<uint8_t>(crc >> 8U);
+        header.crc_l = crc & 0xffU;
 
         std::unique_ptr<uint8_t[]> intermediate_buf = std::unique_ptr<uint8_t[]>(new uint8_t[data_plus_header]);
         ::memcpy(intermediate_buf.get(), &header, header_len);

--- a/ros2_serial_example/test/test_transporter.cpp
+++ b/ros2_serial_example/test/test_transporter.cpp
@@ -278,13 +278,18 @@ TEST_F(PX4TransporterFixture, write_fds_not_ok)
 
 TEST_F(PX4TransporterFixture, write_nullptr)
 {
-    ASSERT_EQ(write(0, nullptr, 0), -1);
+    ASSERT_EQ(write(0, nullptr, 0), 0);
 }
 
 TEST_F(PX4TransporterFixture, write_zero_data)
 {
     std::unique_ptr<uint8_t[]> buf = std::unique_ptr<uint8_t[]>(new uint8_t[4]{});
     ASSERT_EQ(write(0, buf.get(), 0), -1);
+}
+
+TEST_F(PX4TransporterFixture, write_nullptr_with_length)
+{
+    ASSERT_EQ(write(0, nullptr, 4), -1);
 }
 
 TEST_F(PX4TransporterFixture, write)
@@ -395,7 +400,6 @@ std::vector<uint8_t> setup_cobs_long_data()
         size_t header_size = test_data.size();
 
         test_data.resize(header_size + 300 + 1 + 1);
-        fprintf(stderr, "Setting %lu to 0\n", test_data.size() - 1);
         test_data[test_data.size() - 1] = 0x0;
 
         for (size_t i = header_size; i < test_data.size() - 1; ++i)


### PR DESCRIPTION
Support both Crystal and Dashing by allowing 0-sized empty messages.  While we are here, fix up some warnings pointed out by clang-tidy.