### PR TITLE
Fix the build of this repository on Foxy.

### DIFF
--- a/ros2_serial_example/CMakeLists.txt
+++ b/ros2_serial_example/CMakeLists.txt
@@ -78,6 +78,13 @@ foreach(msg ${_msgs})
 endforeach()
 list(REMOVE_DUPLICATES _deps)
 
+# Now setup the libraries for below.
+set(_libs)
+foreach(pkg ${_packages})
+  list(APPEND _libs ${${pkg}_LIBRARIES__rosidl_typesupport_fastrtps_cpp})
+endforeach()
+list(REMOVE_DUPLICATES _libs)
+
 add_library(ring_buffer
   src/ring_buffer.cpp
 )
@@ -98,6 +105,7 @@ ament_target_dependencies(bridge_gen
 )
 target_link_libraries(bridge_gen
   fastcdr
+  ${_libs}
 )
 
 add_library(ros2_to_serial_bridge SHARED
@@ -132,6 +140,7 @@ target_link_libraries(dummy_serial
   fastcdr
   ring_buffer
   transporter
+  ${ros2_serial_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp}
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
@@ -146,6 +155,7 @@ target_link_libraries(dummy_udp
   fastcdr
   ring_buffer
   transporter
+  ${ros2_serial_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp}
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
@@ -170,7 +180,7 @@ install(TARGETS
 )
 
 install(DIRECTORY launch config
- DESTINATION share/${PROJECT_NAME}
+  DESTINATION share/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)

--- a/ros2_serial_example/src/dummy_serial.cpp
+++ b/ros2_serial_example/src/dummy_serial.cpp
@@ -27,7 +27,7 @@
 #include <fastcdr/FastCdr.h>
 
 #include "ros2_serial_msgs/msg/serial_mapping.hpp"
-#include "ros2_serial_msgs/msg/serial_mapping__rosidl_typesupport_fastrtps_cpp.hpp"
+#include "ros2_serial_msgs/msg/detail/serial_mapping__rosidl_typesupport_fastrtps_cpp.hpp"
 
 #include "ros2_serial_example/transporter.hpp"
 #include "ros2_serial_example/uart_transporter.hpp"

--- a/ros2_serial_example/src/dummy_udp.cpp
+++ b/ros2_serial_example/src/dummy_udp.cpp
@@ -27,7 +27,7 @@
 #include <fastcdr/FastCdr.h>
 
 #include "ros2_serial_msgs/msg/serial_mapping.hpp"
-#include "ros2_serial_msgs/msg/serial_mapping__rosidl_typesupport_fastrtps_cpp.hpp"
+#include "ros2_serial_msgs/msg/detail/serial_mapping__rosidl_typesupport_fastrtps_cpp.hpp"
 
 #include "ros2_serial_example/transporter.hpp"
 #include "ros2_serial_example/udp_transporter.hpp"

--- a/ros2_serial_example/src/ros2_to_serial_bridge.cpp
+++ b/ros2_serial_example/src/ros2_to_serial_bridge.cpp
@@ -21,10 +21,10 @@
 #include <fastcdr/Cdr.h>
 
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/empty__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/empty__rosidl_typesupport_fastrtps_cpp.hpp>
 
 #include "ros2_serial_msgs/msg/serial_mapping.hpp"
-#include "ros2_serial_msgs/msg/serial_mapping__rosidl_typesupport_fastrtps_cpp.hpp"
+#include "ros2_serial_msgs/msg/detail/serial_mapping__rosidl_typesupport_fastrtps_cpp.hpp"
 
 #include "ros2_serial_example/ros2_to_serial_bridge.hpp"
 #include "ros2_serial_example/transporter.hpp"

--- a/ros2_serial_example/templates/pub_sub_type.cpp.em
+++ b/ros2_serial_example/templates/pub_sub_type.cpp.em
@@ -21,7 +21,7 @@
 #include <fastcdr/FastCdr.h>
 
 #include <@(ros2_type.ns)/msg/@(ros2_type.lower_type).hpp>
-#include <@(ros2_type.ns)/msg/@(ros2_type.lower_type)__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <@(ros2_type.ns)/msg/detail/@(ros2_type.lower_type)__rosidl_typesupport_fastrtps_cpp.hpp>
 
 #include "@(ros2_type.ns)_@(ros2_type.lower_type)_pub_sub_type.hpp"
 


### PR DESCRIPTION
In Foxy we changed some of the directories that headers were
located, and we also changed it so that you need to link against
the right typesupport library.  Fix both of these things here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@ahcorde Since these changes will not work on Dashing or Eloquent, we may want to consider making a separate branch for those to preserve what did work.